### PR TITLE
feat: prepare repository for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,27 @@
+# Source files
+src/
+tsconfig.json
+test-mcp.js
+
+# Development files
+.env*
+Dockerfile*
+docker-compose.*
+
+# Build artifacts
+node_modules/
+*.log
+*.tmp
+
+# Git files
+.git*
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/package.json
+++ b/package.json
@@ -4,14 +4,32 @@
   "description": "MCP server for executing commands in Docker containers",
   "main": "dist/index.js",
   "type": "module",
+  "bin": {
+    "mcp-server-docker": "dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "jest"
+    "test": "jest",
+    "prepublishOnly": "npm run build"
   },
-  "keywords": ["mcp", "docker", "model-context-protocol"],
-  "author": "",
+  "files": [
+    "dist/**/*",
+    "mcp-config.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": ["mcp", "docker", "model-context-protocol", "cli", "container"],
+  "author": "adamdude828",
+  "homepage": "https://github.com/adamdude828/mcp-server-docker#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adamdude828/mcp-server-docker.git"
+  },
+  "bugs": {
+    "url": "https://github.com/adamdude828/mcp-server-docker/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.6.0",


### PR DESCRIPTION
Prepare repository for npm publishing to enable `npx mcp-server-docker` usage.

## Changes:
- Add bin entry to package.json for npx compatibility
- Add publishing metadata and prepublishOnly script
- Create .npmignore to control published content
- Update README with npx installation instructions
- Fix documentation to reflect STDIO transport usage

Closes #2

Generated with [Claude Code](https://claude.ai/code)